### PR TITLE
Cloud init fixups

### DIFF
--- a/cmd/ros-installer/main.go
+++ b/cmd/ros-installer/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	automatic   = flag.Bool("automatic", false, "Check for and run automatic installation")
 	printConfig = flag.Bool("print-config", false, "Print effective configuration and exit")
-	configFile  = flag.String("config-file", "", "Config file to use, local file or http/tftp URL")
+	configFile  = flag.String("config-file", "/oem/userdata", "Config file to use, local file or http/tftp URL")
 	powerOff    = flag.Bool("power-off", false, "Power off after installation")
 	yes         = flag.Bool("y", false, "Do not prompt for questions")
 )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ users:
 - name: "bar"
   passwd: "foo"
   groups: "users"
+  homedir: "/home/foo"
+  shell: "/bin/bash"
   ssh_authorized_keys:
   - faaapploo
 

--- a/framework/files/etc/systemd/system/rancherd.service.d/override.conf
+++ b/framework/files/etc/systemd/system/rancherd.service.d/override.conf
@@ -1,3 +1,5 @@
 [Unit]
 ConditionPathExists=!/run/cos/live_mode
 ConditionPathExists=!/run/cos/recovery_mode
+After=
+After=cos-setup-network.service

--- a/framework/files/etc/systemd/system/ros-installer.service.d/override.conf
+++ b/framework/files/etc/systemd/system/ros-installer.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=
+After=cos-setup-network.service

--- a/framework/files/system/oem/01_ros-rootfs.yaml
+++ b/framework/files/system/oem/01_ros-rootfs.yaml
@@ -52,7 +52,6 @@ stages:
         device:
           label: COS_PERSISTENT
         expand_partition:
-          size: 0
   network:
     - <<: *datasource
     # Trigger /oem/userdata if was fetched late

--- a/framework/files/system/oem/01_ros-rootfs.yaml
+++ b/framework/files/system/oem/01_ros-rootfs.yaml
@@ -42,6 +42,9 @@ stages:
     # Ensures that if no userdata is found at this stage,
     # we retry later and run the boot hook
     # This is relevant only on first-boot
+    # Mind that userdata can be in the standard cloud-init syntax.
+    # If we don't find any userdata at this stage (because no network is present)
+    # We source the respective fields afterwards
     - if: '[ ! -f /oem/userdata ]'
       files:
       - path: /oem/userdata_load

--- a/framework/files/system/oem/01_ros-rootfs.yaml
+++ b/framework/files/system/oem/01_ros-rootfs.yaml
@@ -34,6 +34,9 @@ stages:
           /var/lib/cni
         PERSISTENT_STATE_BIND: "true"
   rootfs.before:
+    # Try to get network before trying to fetch datasource from the net
+    - commands:
+      - wicked ifup eth0
     - &datasource
       name: "Pull data from provider"
       datasource:

--- a/framework/files/system/oem/01_ros-rootfs.yaml
+++ b/framework/files/system/oem/01_ros-rootfs.yaml
@@ -34,10 +34,17 @@ stages:
           /var/lib/cni
         PERSISTENT_STATE_BIND: "true"
   rootfs.before:
-    - name: "Pull data from provider"
+    - &datasource
+      name: "Pull data from provider"
       datasource:
-        providers: ["cdrom"]
+        providers: ["cdrom", "gcp", "openstack", "aws", "azure", "hetzner", "packet", "scaleway", "vultr", "digitalocean", "metaldata" ]
         path: "/oem"
+    # Ensures that if no userdata is found at this stage,
+    # we retry later and run the boot hook
+    # This is relevant only on first-boot
+    - if: '[ ! -f /oem/userdata ]'
+      files:
+      - path: /oem/userdata_load
   rootfs.after:
     - if: '[ ! -f /run/cos/recovery_mode ] && [ ! -f /run/cos/live_mode ]'
       name: "Grow persistent"
@@ -47,10 +54,15 @@ stages:
         expand_partition:
           size: 0
   network:
-    - name: "Pull data from provider (local)"
-      datasource:
-        providers: ["aws", "gcp", "openstack", "cdrom"]
-        path: "/oem"
+    - <<: *datasource
+    # Trigger /oem/userdata if was fetched late
+    # when network was available
+    # This is relevant only on first-boot
+    - if: '[ -f /oem/userdata ] && [ -f /oem/userdata_load ]'
+      commands:
+      - elemental cloud-init -s initramfs /oem/userdata
+      - elemental cloud-init -s boot /oem/userdata
+      - rm -rf /oem/userdata_load
   fs.before:
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -f /run/cos/live_mode ]'
       name: "Grow persistent fs"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,7 +15,7 @@ export CLOUD_INIT_ISO?=$(ROOT_DIR)/build/ci.iso
 clean: clean_vm_from_iso
 	(vagrant destroy -f) 2> /dev/null || true
 	(vagrant box remove $(BOX_IMAGE)) 2> /dev/null || true
-	rm -rf build-box || true
+	rm -rf build-box build || true
 
 add:
 	vagrant box add --force $(BOX_IMAGE) $(BOX)

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -3,7 +3,8 @@
 
 Vagrant.configure("2") do |config|
     config.vm.guest = :linux
-    config.ssh.username = "vagrant"
+    # Temp workaround for https://github.com/rancher-sandbox/os2/issues/15
+    config.ssh.username = "root"
     config.vm.boot_timeout = 460
     config.ssh.connect_timeout = 360
     config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/tests/assets/cloud_init.yaml
+++ b/tests/assets/cloud_init.yaml
@@ -6,9 +6,19 @@ users:
   passwd: "ros"
   ssh_authorized_keys:
   - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
-- name: "vagrant"
-  passwd: "vagrant"
-  shell: "/bin/bash"
-  homedir: "/run/vagrant"
-  ssh_authorized_keys:
-  - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
+# - name: "vagrant"
+#   passwd: "vagrant"
+#   shell: "/bin/bash"
+#   homedir: "/run/vagrant"
+#   ssh_authorized_keys:
+#   - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
+
+# Temp workaround for https://github.com/rancher-sandbox/os2/issues/15. 
+# Uncomment the lines commented before and drop runcmd when it is closed.
+runcmd:
+- systemctl start wicked
+#- useradd -d /run/vagrant -U -s /bin/bash -m vagrant
+- mkdir /root/.ssh
+- curl -L https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub -o /root/.ssh/authorized_keys
+- chmod 700 /root/.ssh
+- chmod 600 /root/.ssh/authorized_keys

--- a/tests/assets/cloud_init.yaml
+++ b/tests/assets/cloud_init.yaml
@@ -8,5 +8,7 @@ users:
   - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
 - name: "vagrant"
   passwd: "vagrant"
+  shell: "/bin/bash"
+  homedir: "/run/vagrant"
   ssh_authorized_keys:
   - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub

--- a/tests/assets/cloud_init.yaml
+++ b/tests/assets/cloud_init.yaml
@@ -1,30 +1,12 @@
-# Note: This cloud-init doesn't use the standard cloud-init config probably due to: https://github.com/rancher/os2/issues/7
-# As a workaround, use the internal extended syntax
-stages:
-   network:
-     - name: "Setup users"
-       ensure_entities:
-       - path: /etc/passwd
-         entity: |
-            kind: "user"
-            username: "vagrant"
-            password: "x"
-            homedir: "/run/tmp/vagrant"
-            shell: "/bin/bash"
-       - path: /etc/shadow
-         entity: |
-            kind: "shadow"
-            username: "vagrant"
-            password: ""
-       - path: /etc/shadow
-         entity: |
-            kind: "shadow"
-            username: "root"
-            password: "ros"
-       commands:
-       - mkdir -p /run/tmp/vagrant
-     - name: "Setup pubkey"
-       authorized_keys:
-        vagrant:
-        - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
-name: "Setup for the vagrant user"
+#cloud-config
+
+# Add additional users or set the password/ssh keys for root
+users:
+- name: "root"
+  passwd: "ros"
+  ssh_authorized_keys:
+  - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
+- name: "vagrant"
+  passwd: "vagrant"
+  ssh_authorized_keys:
+  - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -153,7 +153,7 @@ var _ = Describe("os2 Smoke tests", func() {
 				Eventually(func() string {
 					out, _ := s.Command("k3s kubectl apply -f /usr/local/setting.yaml")
 					return out
-				}, 6*time.Minute, 30*time.Second).Should(
+				}, 15*time.Minute, 30*time.Second).Should(
 					Or(
 						ContainSubstring("unchanged"),
 						ContainSubstring("configured"),
@@ -163,12 +163,12 @@ var _ = Describe("os2 Smoke tests", func() {
 				Eventually(func() string {
 					out, _ := s.Command("KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm -n cattle-rancheros-operator-system install --create-namespace rancheros-operator /usr/local/ros.tgz")
 					return out
-				}, 6*time.Minute, 2*time.Second).Should(ContainSubstring("STATUS: deployed"))
+				}, 15*time.Minute, 2*time.Second).Should(ContainSubstring("STATUS: deployed"))
 
 				Eventually(func() string {
 					out, _ := s.Command("k3s kubectl get pods --all-namespaces")
 					return out
-				}, 6*time.Minute, 2*time.Second).Should(ContainSubstring("rancheros-operator-"))
+				}, 15*time.Minute, 2*time.Second).Should(ContainSubstring("rancheros-operator-"))
 			})
 
 			By("adding a machine registration", func() {


### PR DESCRIPTION
This PR is multi-fold and contains several fixups I've found while digging cloud-init issues. The changes are split into separate commit for a better review. 

It introduces some logical changes, while until now all other changes were pretty cosmetical:

- ros-installer by default reading /oem/userdata for automated installation
- services have been reworked to wait on cos-setup-network rather network-online. This ensures userdata is loaded so installation configuration is picked up correctly
- cloud-init datasources logic changed slightly: in order to be sure that we pull the data from the network, we call explictly the userdata fetched if none was found previously. This impact only first-boot as subsequent boots have the userdata pulled correctly. I would suggest in the long term to encode cloud-init files directly in the `network` stage to be sure we have the network. But since this is optional and at our discretion, this PR enforces this behavior, see https://github.com/rancher-sandbox/cOS-toolkit/issues/1124 for a follow-up.

Fixes: https://github.com/rancher-sandbox/os2/issues/9
Fixes: https://github.com/rancher-sandbox/os2/issues/8
Fixes: https://github.com/rancher/os2/issues/14