### PR TITLE
Enable TPM emulation

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,7 +11,8 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       DOCKER_REGISTRY: quay.io
       REPO: quay.io/costoolkit/os2-ci
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    #runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd /usr/src && \
     CGO_ENABLED=0 go build -ldflags "-extldflags -static -s" -o /usr/sbin/ros-operator ./cmd/ros-operator && \
     upx /usr/sbin/ros-operator
 RUN cd /usr/src && \
-    CGO_ENABLED=0 go build -ldflags "-extldflags -static -s" -o /usr/sbin/ros-installer ./cmd/ros-installer && \
+    go build -o /usr/sbin/ros-installer ./cmd/ros-installer && \
     upx /usr/sbin/ros-installer
 
 FROM quay.io/luet/base:0.22.7-1 AS framework-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM quay.io/luet/base:0.22.7-1 as luet
 FROM base AS build
 ENV LUET_NOLOCK=true
 ENV USER=root
-RUN zypper in -y squashfs xorriso go1.16 upx busybox-static curl tar git gzip
+RUN zypper in -y squashfs xorriso go1.16 upx busybox-static curl tar git gzip openssl-devel
 COPY framework/files/etc/luet/luet.yaml /etc/luet/luet.yaml
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 RUN luet install -y utils/helm

--- a/framework/files/etc/cos/bootargs.cfg
+++ b/framework/files/etc/cos/bootargs.cfg
@@ -2,7 +2,7 @@ set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5"
 else
-    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemlabel=COS_OEM"
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemlabel=COS_OEM rd.neednet=1"
 fi
 
 set initramfs=/boot/initrd

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -295,7 +295,7 @@ func returnRegistrationData(url, ca, emulatedTPM, TPMSeed, noSmbios string) (map
 		if TPMSeed != "" {
 			s, err := strconv.ParseInt(TPMSeed, 10, 64)
 			if err == nil {
-				logrus.Info("TPM Emulation Seed", s)
+				logrus.Infof("TPM Emulation Seed '%s'", TPMSeed)
 				opts = append(opts, tpm.WithSeed(s))
 			}
 		} else {


### PR DESCRIPTION
The following commit enables TPM emulation and its configuration in the
os2 configuration file.

TPM Emulation is considered unsafe and meant only for testing purposes.

For example, to enable tpm emulation with a static seed, disabling also
smbios headers:
```
rancheros:
  tpm:
    emulated: true
    no_smbios: true
    seed: "5"
```

It also adds a specific test for config file reading via ws with tpm.

Closes: https://github.com/rancher-sandbox/os2/issues/20

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>