### PR TITLE
Do not nullify the extra data from the config

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -75,7 +75,6 @@ func runInstall(cfg config.Config, output string) error {
 		if err != nil || !val {
 			return err
 		}
-		cfg.Data = nil
 	}
 
 	if cfg.RancherOS.Install.ConfigURL == "" && !cfg.RancherOS.Install.Automatic {


### PR DESCRIPTION
For some reason the installer was assuming that if you dont do an
automatic installation, your "extra data" from the config file should be
gone.

I do not understand why as automatic is not the same as providing a
config file with values which may have nothing to do with the
installation.

This patch removes the nulling of the extra data

Fixes #24 

Signed-off-by: Itxaka <igarcia@suse.com>