### PR TITLE
Reduce framework image by copying only needed files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,11 @@ RUN utils/rancherd@0.0.1-alpha13-3
 RUN utils/helm
 
 FROM scratch AS framework
-COPY --from=framework-build /framework /
+COPY --from=framework-build /framework/etc /etc
+COPY --from=framework-build /framework/lib /lib
+COPY --from=framework-build /framework/usr /usr
+COPY --from=framework-build /framework/system /system
+COPY --from=framework-build /framework/var/lib /var/lib
 COPY --from=build /usr/src/dist/rancheros-operator-chart.tgz /usr/share/rancher/os2/
 COPY framework/files/etc/luet/luet.yaml /etc/luet/luet.yaml
 COPY --from=build /usr/sbin/ros-installer /usr/sbin/ros-installer


### PR DESCRIPTION
As we cannot clean the image afterwards due to it having scratch as
base, so no utils to rm, we are bringing several caches and metadata
from luet which kind of doubles the image size.

This patch reduces the image size to half by specifically copying the
required dirs in order to avoid bringing caches and repo files from luet

Signed-off-by: Itxaka <igarcia@suse.com>