### PR TITLE
Do not require a container image or isoURL

### DIFF
--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -245,10 +245,6 @@ func updateData(ctx context.Context, data map[string]interface{}) (map[string]in
 					if newContainerImage == "" {
 						values.PutValue(newData, ContainerImage, "rancheros", "install", "containerImage")
 					}
-					// If everything is empty, error out, we have no source for install
-					if newISOURL == "" && isoURL == "" && newContainerImage == "" && ContainerImage == "" {
-						return nil, fmt.Errorf("rancheros.install.iso_url/containerImage is required to be set in /proc/cmdline or in MachineRegistration in .spec.cloudConfig.rancheros.install.isoUrl/containerImage")
-					}
 					// Return the data obtained from the registration url with our full data
 					return newData, nil
 				}

--- a/pkg/config/read_test.go
+++ b/pkg/config/read_test.go
@@ -469,5 +469,33 @@ rancheros:
 			Expect(c.RancherOS.Install.ContainerImage).To(Equal("test"))
 		})
 
+		It("doesn't error out if isoUrl or containerImage are not provided", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Override the install value on the data
+			value := map[string]string{}
+			values.PutValue(data, value, "rancheros", "install")
+
+			WSServer(ctx, data)
+			f, err := ioutil.TempFile("", "xxxxtest")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(f.Name())
+
+			_ = ioutil.WriteFile(f.Name(), []byte(`
+rancheros:
+  tpm:
+    emulated: true
+    no_smbios: true
+    seed: "5"
+  install:
+    registrationUrl: "http://127.0.0.1:9980/test"
+`), os.ModePerm)
+
+			c, err := ReadConfig(ctx, f.Name(), false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.RancherOS.Install.ContainerImage).To(Equal(""))
+			Expect(c.RancherOS.Install.ISOURL).To(Equal(""))
+		})
 	})
 })


### PR DESCRIPTION
During automated installation it was previously required to specify
either a containerImage or a isoUrl, but this is something we impose
ourselves, as elemental otherwise would install from the booting source.

Fixes: https://github.com/rancher-sandbox/cOS-toolkit/issues/1166

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>