### PR TITLE
Disable verify

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,14 +4,17 @@ on:
 concurrency:
   group: integration-tests=full-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
+
+env:
+   DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+   DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+   DOCKER_REGISTRY: quay.io
+   REPO: quay.io/costoolkit/os2-ci
+   REPO_ROS_OPERATOR: quay.io/costoolkit/ros-operator-ci
+
 jobs:
   build:
-    env:
-      DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-      DOCKER_REGISTRY: quay.io
-      REPO: quay.io/costoolkit/os2-ci
-      REPO_ROS_OPERATOR: quay.io/costoolkit/ros-operator-ci
+
     runs-on: ubuntu-latest
     #runs-on: self-hosted
     steps:
@@ -35,6 +38,50 @@ jobs:
           sudo rm -rf bin || true
           sudo rm -rf dist || true
           docker system prune -f -a --volumes || true
+  tests-installer:
+    runs-on: macos-10.15
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.17'
+      - name: Install deps
+        run: |
+          brew install cdrtools jq
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+      - run: |
+              ls -liah
+              ls -liah artifacts
+              mv artifacts/*.iso ros.iso
+              mv artifacts/*.tgz ros-operator.tgz
+              rm -rf artifacts
+      - name: OS version
+        id: version
+        run: |
+          source scripts/version
+          # Set output parameters.
+          echo ::set-output name=tag::${TAG}
+      - name: Run tests
+        env:
+          BOX_URL: ${{ github.event.inputs.box-image }}
+        run: |
+          export COS_HOST=127.0.0.1:2222
+          export ROS_CHART=$PWD/ros-operator.tgz
+          export ISO=$PWD/ros.iso
+          export CONTAINER_IMAGE=$REPO:${{ steps.version.outputs.tag }}
+          make deps
+          cd tests && make installer-tests
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ros-vbox.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
   tests-vbox:
     runs-on: macos-10.15
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM opensuse/leap:15.3 as base
-RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf && \
-    sed -i 's/download/provo-mirror/g' /etc/zypp/repos.d/*repo
+RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf
 RUN zypper ref
 
 FROM quay.io/luet/base:0.22.7-1 as luet

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,5 @@
 FROM opensuse/leap:15.3
-RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf && \
-    sed -i 's/download/provo-mirror/g' /etc/zypp/repos.d/*repo
+RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf
 RUN zypper ref
 
 ARG DAPPER_HOST_ARCH

--- a/Dockerfile.kvm
+++ b/Dockerfile.kvm
@@ -1,6 +1,5 @@
 FROM opensuse/leap:15.3
-RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf && \
-    sed -i 's/download/provo-mirror/g' /etc/zypp/repos.d/*repo
+RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf
 RUN zypper ref
 RUN zypper install -y socat net-tools-deprecated libtasn1-devel gnutls-devel libseccomp-devel json-glib-devel system-user-tss git
 RUN zypper install -y autoconf

--- a/framework/files/etc/cos/config
+++ b/framework/files/etc/cos/config
@@ -2,8 +2,9 @@
 # This file allows to tweak cOS configuration such as: default upgrade/recovery image and GRUB menu entry
 
 # Disable/enable image verification during upgrades ( default: true )
-VERIFY=false
-_COSIGN=false
+NO_VERIFY=true
+
+COSIGN=false
 
 # Disable/enable upgrades via release channels instead of container images. ( default: true )
 CHANNEL_UPGRADES=false

--- a/framework/files/etc/luet/luet.yaml
+++ b/framework/files/etc/luet/luet.yaml
@@ -12,12 +12,12 @@ repositories:
   arch: "amd64"
   # Enable/disable Docker notary checks
   # 
-  reference: 20220302200031-repository.yaml
+  reference: 20220313190659-repository.yaml
   verify: false
   urls:
   - "quay.io/costoolkit/releases-green"
 - <<: *cos
   arch: "arm64"
-  reference: 20220302210559-repository.yaml
+  reference: 20220313193615-repository.yaml
   urls:
   - "quay.io/costoolkit/releases-green-arm64"

--- a/framework/files/system/oem/01_ros-rootfs.yaml
+++ b/framework/files/system/oem/01_ros-rootfs.yaml
@@ -58,6 +58,7 @@ stages:
         device:
           label: COS_PERSISTENT
         expand_partition:
+          size: 0
   # XXX:
   # Fetch datasources ONLY when network is present
   # This prevents network configuration via cloud-init from datasources.

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -131,9 +131,12 @@ func runInstall(cfg config.Config, output string) error {
 
 	printEnv(cfg)
 
-	cmd := exec.Command("cos-installer")
+	installerOpts := []string{"elemental", "install", "--no-verify"}
+
+	cmd := exec.Command("elemental")
 	cmd.Env = append(os.Environ(), ev...)
 	cmd.Stdout = os.Stdout
+	cmd.Args = installerOpts
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/ros-image-build
+++ b/ros-image-build
@@ -261,7 +261,7 @@ VERSION=${IMAGE##*:}
 GIT_COMMIT=${GIT_COMMIT:-HEAD}
 NAME=${IMAGE%%:${VERSION}}
 NAME=${NAME//[^a-zA-Z0-9-@.\/_]/-}
-COS_VERSION=${COS_VERSION:-b4924c9807ceee79ca9c7dc1a266af2f6e326474}
+COS_VERSION=${COS_VERSION:-781cc657aa5ea16b8fe978b8d4bcd19740943db0}
 
 if [ "$1" == dockerfile ]; then
     dockerfile

--- a/ros-image-build
+++ b/ros-image-build
@@ -17,8 +17,7 @@ ARG IMAGE=rancher/os2:dev
 FROM ${IMAGE} AS os
 
 FROM ${IMAGE} AS tools
-RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf && \
-    sed -i 's/download/provo-mirror/g' /etc/zypp/repos.d/*repo
+RUN sed -i -s 's/^# rpm.install.excludedocs/rpm.install.excludedocs/' /etc/zypp/zypp.conf
 RUN zypper ref
 ENV LUET_NOLOCK=true
 # Copy luet from the official images

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,7 +37,7 @@ run:
 
 .PHONY: install
 install:
-	ginkgo -r ./install
+	ginkgo --label-filter setup -r ./install
 
 build/ci.iso:
 	./prepare_cloudinit
@@ -70,3 +70,14 @@ clean_vm_from_iso:
 	VBoxManage controlvm "test" poweroff &>/dev/null || true
 	VBoxManage unregistervm "test" --delete &>/dev/null || true
 	VBoxManage closemedium disk sda.vdi --delete &>/dev/null || true
+
+installer-tests: build-box/sda.vdi
+	VBoxManage createvm --name "test" --register
+	VBoxManage modifyvm "test" --memory 10240 --cpus 3
+	VBoxManage modifyvm "test" --nic1 nat --boot1 disk --boot2 dvd --natpf1 "guestssh,tcp,,2222,,22"
+	VBoxManage storagectl "test" --name "sata controller" --add sata --portcount 2 --hostiocache off
+	VBoxManage storageattach "test" --storagectl "sata controller" --port 0 --device 0 --type hdd --medium build-box/sda.vdi
+	VBoxManage storageattach "test" --storagectl "sata controller" --port 1 --device 0 --type dvddrive --medium $(ISO)
+	VBoxManage startvm "test" --type headless
+	ginkgo --label-filter "!setup" -r ./install
+	VBoxManage controlvm "test" poweroff &>/dev/null || true

--- a/tests/install/install_test.go
+++ b/tests/install/install_test.go
@@ -4,9 +4,40 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/os2/tests/sut"
+	"os"
 )
 
-var _ = Describe("os2 install tests", func() {
+var _ = Describe("os2 installation", Label("setup"), func() {
+	var s *sut.SUT
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+
+	// This is used to setup the machine that will run other tests
+	Context("First boot", func() {
+		It("can install", func() {
+
+			s.WriteInlineFile(`
+rancheros:
+ install:
+   device: /dev/sda
+   automatic: true
+`, "/oem/userdata")
+
+			out, err := s.Command("ros-installer --automatic --no-reboot-automatic && sync")
+			Expect(out).To(And(
+				ContainSubstring("Unmounting disk partitions"),
+				ContainSubstring("Mounting disk partitions"),
+				ContainSubstring("Finished copying COS_PASSIVE"),
+				ContainSubstring("Grub install to device /dev/sda complete"),
+			))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("os2 setup tests", func() {
 	var s *sut.SUT
 	BeforeEach(func() {
 		s = sut.NewSUT()
@@ -14,14 +45,29 @@ var _ = Describe("os2 install tests", func() {
 	})
 
 	Context("First boot", func() {
-		It("can install", func() {
-			out, err := s.Command("ELEMENTAL_TARGET=/dev/sda elemental install && sync")
+		It("can install from a container image", func() {
+
+			containerImage := os.Getenv("CONTAINER_IMAGE")
+			if containerImage == "" {
+				Skip("No CONTAINER_IMAGE defined")
+			}
+
+			s.WriteInlineFile(`
+rancheros:
+ install:	
+   device: /dev/sda
+   containerImage: `+containerImage+`
+   automatic: true
+`, "/oem/userdata")
+
+			out, err := s.Command("ros-installer --automatic --no-reboot-automatic && sync")
 			Expect(out).To(And(
 				ContainSubstring("Unmounting disk partitions"),
 				ContainSubstring("Mounting disk partitions"),
 				ContainSubstring("Finished copying COS_PASSIVE"),
+				ContainSubstring("Unpacking docker image: "+containerImage),
 				ContainSubstring("Grub install to device /dev/sda complete"),
-			))
+			), out)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -191,7 +191,7 @@ var _ = Describe("os2 Smoke tests", func() {
 
 				Eventually(func() string {
 					out, _ := s.Command("k3s kubectl get pods --all-namespaces")
-					return out
+					return out	
 				}, 15*time.Minute, 2*time.Second).Should(ContainSubstring("rancheros-operator-"))
 			})
 

--- a/tests/sut/sut.go
+++ b/tests/sut/sut.go
@@ -468,3 +468,10 @@ func DialWithDeadline(network string, addr string, config *ssh.ClientConfig, tim
 	}()
 	return ssh.NewClient(c, chans, reqs), nil
 }
+
+func (s *SUT) WriteInlineFile(content, path string) {
+	_, err := s.Command(`cat << EOF > ` + path + `
+` + content + `
+EOF`)
+	Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
This PR disables `VERIFY` so mtree is not required (see #49).

Besides, tries to add a small test to make sure container image installation works, alongside it also rework the test to use `ros-installer` instead of `elemental install`.