### PR TITLE
Add flag for ejecting the cd when restarting

### DIFF
--- a/cmd/ros-installer/main.go
+++ b/cmd/ros-installer/main.go
@@ -35,6 +35,7 @@ var (
 	reboot            = flag.Bool("reboot", false, "Reboot after installation")
 	noRebootAutomatic = flag.Bool("no-reboot-automatic", false, "Dont reboot after installation (only for automatic installation which defaults to reboot after install)")
 	yes               = flag.Bool("y", false, "Do not prompt for questions")
+	ejectCD           = flag.Bool("eject-cd", false, "Ejects the CD on system reboot")
 )
 
 func main() {
@@ -52,7 +53,7 @@ func main() {
 		return
 	}
 
-	if err := install.Run(*automatic, *configFile, *powerOff, *reboot, *noRebootAutomatic, *yes); err != nil {
+	if err := install.Run(*automatic, *configFile, *powerOff, *reboot, *noRebootAutomatic, *yes, *ejectCD); err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type Install struct {
 	Password           string `json:"password,omitempty"`
 	RegistrationURL    string `json:"registrationUrl,omitempty"`
 	RegistrationCACert string `json:"registrationCaCert,omitempty"`
+	EjectCd            bool   `json:"ejectCd,omitempty"`
 }
 
 type Config struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ type Install struct {
 	Password           string `json:"password,omitempty"`
 	RegistrationURL    string `json:"registrationUrl,omitempty"`
 	RegistrationCACert string `json:"registrationCaCert,omitempty"`
-	EjectCd            bool   `json:"ejectCd,omitempty"`
+	EjectCD            bool   `json:"ejectCD,omitempty"`
 }
 
 type Config struct {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -28,12 +28,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func Run(automatic bool, configFile string, powerOff bool, reboot bool, noRebootAutomatic bool, silent bool) error {
+func Run(automatic bool, configFile string, powerOff bool, reboot bool, noRebootAutomatic bool, silent bool, ejectCd bool) error {
 	cfg, err := config.ReadConfig(context.Background(), configFile, automatic)
 	if err != nil {
 		return err
 	}
 
+	if ejectCd {
+		cfg.RancherOS.Install.EjectCd = true
+	}
 	if powerOff {
 		cfg.RancherOS.Install.PowerOff = true
 	}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -28,14 +28,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func Run(automatic bool, configFile string, powerOff bool, reboot bool, noRebootAutomatic bool, silent bool, ejectCd bool) error {
+func Run(automatic bool, configFile string, powerOff bool, reboot bool, noRebootAutomatic bool, silent bool, ejectCD bool) error {
 	cfg, err := config.ReadConfig(context.Background(), configFile, automatic)
 	if err != nil {
 		return err
 	}
 
-	if ejectCd {
-		cfg.RancherOS.Install.EjectCd = true
+	if ejectCD {
+		cfg.RancherOS.Install.EjectCD = true
 	}
 	if powerOff {
 		cfg.RancherOS.Install.PowerOff = true


### PR DESCRIPTION
Leverage the elemental CLI flag that allows to eject the cd when
restarting

This is part 3 of https://github.com/rancher-sandbox/os2/issues/31
Requires: https://github.com/rancher-sandbox/cOS-toolkit/pull/1191
Requires: https://github.com/rancher-sandbox/elemental/pull/156

Signed-off-by: Itxaka <igarcia@suse.com>