### PR TITLE
Do not upload iso/qcow/box with the artifacts - do not download all artifacts for test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,7 +70,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: artifacts
+          name: iso
+          path: artifacts
       - run: |
               ls -liah
               ls -liah artifacts
@@ -112,7 +113,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: artifacts
+          name: iso
+          path: artifacts
       - run: |
               ls -liah
               ls -liah artifacts
@@ -144,7 +146,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: artifacts
+          name: box
+          path: artifacts
       - run: |
               ls -liah
               ls -liah artifacts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,7 +27,11 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: artifacts
-          path: dist
+          path: |
+            dist/artifacts/*
+            !dist/artifacts/*.iso
+            !dist/artifacts/*.qcow.gz
+            !dist/artifacts/*.box
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
It makes no sense as we upload them twice and we only need the iso/box
in the following jobs

Signed-off-by: Itxaka <igarcia@suse.com>