### PR TITLE
Fix ros-image-build and update docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ Kubernetes operators.
 
 ## Use Cases
 
-RancherOS is intended to be ran as the operating system beneath a Rancher Multi-Cluster 
+RancherOS is intended to be run as the operating system beneath a Rancher Multi-Cluster 
 Management server or as a node in a Kubernetes cluster managed by Rancher. RancherOS
 also allows you to build stand alone Kubernetes clusters that run an embedded
 and smaller version of Rancher to manage the local cluster. A key attribute of RancherOS

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -8,7 +8,7 @@ following Dockerfile
 
 ```Dockerfile
 # The version of RancherOS to modify
-FROM rancher/os2:v0.0.1-test01
+FROM rancher-sandbox/os2:v0.0.1-test01
 
 # Your custom commands
 RUN zypper install -y cowsay
@@ -45,7 +45,7 @@ run the below command
 
 ```bash
 # Download the ros-image-build script
-curl -o ros-image-build https://raw.githubusercontent.com/rancher/os2/main/ros-image-build
+curl -o ros-image-build https://raw.githubusercontent.com/rancher-sandbox/os2/main/ros-image-build
 
 # Run the script creating a qcow image, an ISO, and an AMI
 bash ros-image-build myrepo/custom-build:v1.1.1 qcow,iso,ami

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -8,7 +8,7 @@ following Dockerfile
 
 ```Dockerfile
 # The version of RancherOS to modify
-FROM rancher-sandbox/os2:v0.0.1-test01
+FROM rancher-sandbox/os2:VERSION
 
 # Your custom commands
 RUN zypper install -y cowsay
@@ -21,6 +21,8 @@ RUN echo "IMAGE_REPO=${IMAGE_REPO}"          > /usr/lib/rancheros-release && \
     echo "IMAGE_TAG=${IMAGE_TAG}"           >> /usr/lib/rancheros-release && \
     echo "IMAGE=${IMAGE_REPO}:${IMAGE_TAG}" >> /usr/lib/rancheros-release
 ```
+
+Where VERSION is the base version we want to customize. All version numbers available at [quay.io](https://quay.io/repository/costoolkit/os2?tab=tags) or [github](https://github.com/rancher-sandbox/os2/releases)
 
 And then the following commands
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,7 +74,7 @@ ros-installer -config-file ${LOCATION}
 
 ### Interactive
 
-`ros-installer` can also be ran without any arguments to allow you to install a simple vanilla image with a
+`ros-installer` can also be run without any arguments to allow you to install a simple vanilla image with a
 root password set.
 
 ## iPXE Installation

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -27,7 +27,7 @@ metadata:
   namespace: fleet-local
 spec:
   # Set to the new RancherOS version you would like to upgrade to
-  osImage: rancher/os2:v0.0.0
+  osImage: quay.io/costoolkit/os2:v0.0.0
 ```
 
 ## rancherd

--- a/ros-image-build
+++ b/ros-image-build
@@ -2,6 +2,9 @@
 # Note: ros-image-build requires the input image to be pushed 
 # due to buildx usage.
 
+# Export  this here so users dont need to
+export DOCKER_BUILDKIT=1
+
 set -e
 
 build()


### PR DESCRIPTION
 - Export DOCKER_BUILDKIT=1 in the ros-image-build script so users dont
need to
 - Update references to ranchor/os2 to rancher-sandbox/os2
 - Update references to os2 images to point to quay
 - Some minor changes in phrasing

Fixes https://github.com/rancher/os2/issues/17
Fixes https://github.com/rancher-sandbox/os2/issues/51

Signed-off-by: Itxaka <igarcia@suse.com>