### PR TITLE
ci: use new runner for bootstrap test + force Golang v1.17.x

### DIFF
--- a/.github/workflows/install-with-rancher.yaml
+++ b/.github/workflows/install-with-rancher.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: kvm-host
     env:
       DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -39,7 +39,7 @@ jobs:
           sudo rm -rf build bin dist
           docker system prune -f -a --volumes
   install-with-rancher:
-    runs-on: nested-virt
+    runs-on: kvm-host
     needs: build
     container:
       image: opensuse/leap:latest

--- a/.github/workflows/integration-tests-manual.yaml
+++ b/.github/workflows/integration-tests-manual.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.17'
+            go-version: '~1.17'
       - name: Install deps
         run: |
           brew install cdrtools jq
@@ -49,7 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.17'
+            go-version: '~1.17'
       - name: Install deps
         run: |
           sudo apt-get update

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.17'
+            go-version: '~1.17'
       - name: Install deps
         run: |
           brew install cdrtools jq
@@ -106,7 +106,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.17'
+            go-version: '~1.17'
       - name: Install deps
         run: |
           brew install cdrtools jq
@@ -142,7 +142,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '~1.17'
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/static_analisys.yaml
+++ b/.github/workflows/static_analisys.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '~1.17'
     - name: Analysis
       uses: golangci/golangci-lint-action@v3
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '~1.17'
     - name: Get dependencies
       run: |
         # Needed for github.com/google/go-tspi/tspi


### PR DESCRIPTION
Should fix #61.

This PR also force Golang v1.17.x