### PR TITLE
ci: use scsi device instead of virtio for e2e tests

### DIFF
--- a/tests/assets/machineregistration.yaml
+++ b/tests/assets/machineregistration.yaml
@@ -13,8 +13,10 @@ spec:
   # The cloud config that will be used to provision the node
   cloudConfig:
     hostname: ros-node-{{ trunc 4 .MachineID }}
-    install:
-      device: /dev/vda
     users:
     - name: root
-      passwd: root
+      passwd: r0s@pwd1
+    rancheros:
+      install:
+        device: /dev/sda
+        debug: true

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -16,7 +16,7 @@ script -e -c "virt-install \
   --ram=2048 \
   --vcpus=2 \
   --cpu host \
-  --disk path=hdd.img,bus=virtio,size=35 \
+  --disk path=hdd.img,bus=scsi,size=35 \
   --check disk_size=off \
   --graphics none \
   --serial pty \


### PR DESCRIPTION
This commit also fix the install device issue (should be under `rancheros` section).
Also use a "real" password for root user.