### PR TITLE
ci: fix tests-installer test

### DIFF
--- a/tests/install/install_test.go
+++ b/tests/install/install_test.go
@@ -82,7 +82,7 @@ rancheros:
 				ContainSubstring("Unmounting disk partitions"),
 				ContainSubstring("Mounting disk partitions"),
 				ContainSubstring("Finished copying COS_PASSIVE"),
-				ContainSubstring("Unpacking docker image: "+containerImage),
+				ContainSubstring("Unpacking a container image: "+containerImage),
 				ContainSubstring("Grub install to device /dev/sda complete"),
 			), out)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This should fix CI issues in `tests-installer` like these ones: https://github.com/rancher-sandbox/os2/runs/6562655472?check_suite_focus=true and https://github.com/rancher-sandbox/os2/runs/6562756308?check_suite_focus=true